### PR TITLE
fix missing Left brace in CPL03 decoder

### DIFF
--- a/CPL03-LB/CPL03-LB_TTN_v1.1.1_decoder.txt
+++ b/CPL03-LB/CPL03-LB_TTN_v1.1.1_decoder.txt
@@ -187,7 +187,7 @@ function Decoder(bytes, port) {
     }
     else if(work_mod=="CPL03")
     {
-      return 
+      return {
 	  Node_type:"CPL03-LB",
       WORKMOD:work_mod,
       CMOD:count_mod,  


### PR DESCRIPTION
The code does not work because an opening brace was missing.