### PR TITLE
Fixed fPort variable name typo in DDS75-LB_ChirpstackV4_Decoder.txt

### DIFF
--- a/DDS75-LB/DDS75-LB_ChirpstackV4_Decoder.txt
+++ b/DDS75-LB/DDS75-LB_ChirpstackV4_Decoder.txt
@@ -51,7 +51,7 @@ function getMyDate(str){
 }
 
 function Decode(fPort, bytes, variables) {
-   if (port == 0x02) {
+   if (fPort == 0x02) {
         // Check the 5th bit of the first byte
         if (bytes[0] & 0x10) { // 0x10 is binary 00010000, which corresponds to the 5th bit
             // Only parse batV and additional distance data


### PR DESCRIPTION
When change was made by [commit 802e816](https://github.com/dragino/dragino-end-node-decoder/commit/802e8160c3c351084295c85f86f179d424398c4d) the variable 'fPort' was changed to 'port' which caused an error