### PR TITLE
Fix issue with LDS12-LB chirpstack v4 decoder

### DIFF
--- a/LDS12-LB/LDS12-LB_v1.0_Decoder_ChirpstackV4.txt
+++ b/LDS12-LB/LDS12-LB_v1.0_Decoder_ChirpstackV4.txt
@@ -89,10 +89,10 @@ function Decode(fPort, bytes, variables) {
       else
         data_sum+=data;
     }
-    return
-	Node_type:"LDS12-LB",
-    DATALOG:data_sum,
-    PNACKMD:pnack,
+    return {
+	    Node_type:"LDS12-LB",
+      DATALOG:data_sum,
+      PNACKMD:pnack,
     };    
   }  
   else if(fPort==0x05)


### PR DESCRIPTION
This fixes a small syntax error in the LDS12-LB decoder for chirpstack v4. Without this, an error will occur.